### PR TITLE
Bumping jest-cli dependency from ^0.1.17 to ^0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/leebyron/grunt-jest",
   "peerDependencies": {
-    "jest-cli": "^0.1.17"
+    "jest-cli": "^0.2.1"
   }
 }


### PR DESCRIPTION
jest-cli has been upgraded to 0.2.x. It would be nice to use these versions along with grunt-jest.
