### PR TITLE
Update jest-cli version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/leebyron/grunt-jest",
   "peerDependencies": {
-    "jest-cli": "0.2.1 - 0.4.x"
+    "jest-cli": "0.2.1 - 0.5.x"
   }
 }


### PR DESCRIPTION
jest-cli v0.5.x is out since September. This PR changes dependency version to 0.2.1 - 0.5.x to support the latest version.
