### PR TITLE
Update jest-cli to its latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/leebyron/grunt-jest",
   "peerDependencies": {
-    "jest-cli": "0.2.1 - 0.4.x"
+    "jest-cli": "^0.6.1"
   }
 }


### PR DESCRIPTION
I've updated the peer dependency to the latest `jest-cli` version (ie: `v0.6.1`) and, at least on the project I'm using this on, everything seems to be working just fine. Is there any reason why you've sticked to these old versions of `jest-cli` instead?

I'm proposing this change since I started getting this warning when running `npm install` on my project:

```
npm WARN peerDependencies The peer dependency jest-cli@0.2.1 - 0.4.x included from grunt-jest will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```

And when I listed `jest-cli` as an explicit dev dependency, I got this incompatibility issue:

```
npm ERR! node v4.2.1
npm ERR! npm  v2.14.7
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package jest-cli@0.6.1 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer grunt-jest@0.1.3 wants jest-cli@0.2.1 - 0.4.x
```

Updating `grunt-jest`'s package.json file to include the latest `jest-cli` version did the trick and apparently that's all it takes to fix this :)

Thanks!
