### PR TITLE
Avoid invalid peer dependency warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/leebyron/grunt-jest",
   "peerDependencies": {
-    "jest-cli": "^0.7.0"
+    "jest-cli": "^0.8.0"
   }
 }


### PR DESCRIPTION
Just noticed a peer dependency warning as I updated jest. :smile: 
